### PR TITLE
Enhancement - Replaced LG Dialog with Bottom Sheet and Side Sheet

### DIFF
--- a/app/src/main/java/com/sidharth/lg_motion/ui/home/fragment/HomeFragment.kt
+++ b/app/src/main/java/com/sidharth/lg_motion/ui/home/fragment/HomeFragment.kt
@@ -15,7 +15,6 @@ import androidx.navigation.NavDirections
 import androidx.navigation.findNavController
 import androidx.recyclerview.widget.LinearSnapHelper
 import com.google.android.material.carousel.CarouselLayoutManager
-import com.sidharth.lg_motion.R
 import com.sidharth.lg_motion.databinding.FragmentHomeBinding
 import com.sidharth.lg_motion.domain.callback.OnFeatureClickCallback
 import com.sidharth.lg_motion.domain.callback.OnFunActivityClickCallback
@@ -50,12 +49,12 @@ class HomeFragment : Fragment(), OnFunActivityClickCallback, OnFeatureClickCallb
 
     override fun onDestroy() {
         super.onDestroy()
-        DialogUtils.dismiss()
+        DialogUtils.dismiss(requireContext())
     }
 
     override fun onPause() {
         super.onPause()
-        DialogUtils.dismiss()
+        DialogUtils.dismiss(requireContext())
     }
 
     override fun onCreateView(
@@ -114,15 +113,8 @@ class HomeFragment : Fragment(), OnFunActivityClickCallback, OnFeatureClickCallb
                     view?.findNavController()?.navigate(it)
                 }
             } else {
-                val isPortrait = resources.getBoolean(R.bool.portrait)
-                val isTablet = resources.getBoolean(R.bool.tablet)
-
-                if (isTablet || isPortrait) {
-                    DialogUtils.show(requireContext()) {
-                        connect()
-                    }
-                } else {
-                    showSnackbar("No LG Connection")
+                DialogUtils.show(requireContext()) {
+                    connect()
                 }
             }
         } else {

--- a/app/src/main/res/layout-land/connection_dialog.xml
+++ b/app/src/main/res/layout-land/connection_dialog.xml
@@ -1,20 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    style="@style/Widget.Material3.BottomSheet.Modal"
+    style="@style/Widget.Material3.SideSheet.Modal"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
-
-    <com.google.android.material.bottomsheet.BottomSheetDragHandleView
-        android:id="@+id/drag_handle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:boxCornerRadiusBottomEnd="15dp"
-        app:boxCornerRadiusBottomStart="15dp"
-        app:boxCornerRadiusTopEnd="15dp"
-        app:boxCornerRadiusTopStart="15dp"
-        app:layout_constraintTop_toTopOf="parent" />
+    app:layout_behavior="com.google.android.material.sidesheet.SideSheetBehavior">
 
     <ScrollView
         android:id="@+id/scroll_form"
@@ -22,15 +12,16 @@
         android:layout_height="wrap_content"
         android:isScrollContainer="true"
         android:nestedScrollingEnabled="true"
-        android:paddingBottom="115dp"
+        android:paddingBottom="55dp"
         app:layout_constraintBottom_toTopOf="@id/button_layout"
-        app:layout_constraintTop_toBottomOf="@id/drag_handle"
+        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:padding="15dp">
+            android:paddingHorizontal="15dp"
+            android:paddingVertical="5dp">
 
             <TextView
                 android:id="@+id/txt_title"
@@ -38,7 +29,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/connection_dialog_title"
                 android:textColor="@color/base_theme_light_primary"
-                android:textSize="18sp"
+                android:textSize="16sp"
                 android:textStyle="bold"
                 app:layout_constraintBottom_toTopOf="@id/txt_description"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -184,6 +175,8 @@
         android:layout_height="wrap_content"
         android:background="#fff"
         android:orientation="horizontal"
+        android:paddingHorizontal="15dp"
+        android:paddingVertical="5dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent">
@@ -215,7 +208,6 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:padding="15dp"
             app:constraint_referenced_ids="btn_cancel, btn_connect"
             app:flow_horizontalGap="15dp"
             app:flow_verticalAlign="center"

--- a/app/src/main/res/layout-sw600dp/connection_dialog.xml
+++ b/app/src/main/res/layout-sw600dp/connection_dialog.xml
@@ -1,20 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    style="@style/Widget.Material3.BottomSheet.Modal"
+    style="@style/Widget.Material3.SideSheet.Modal"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
-
-    <com.google.android.material.bottomsheet.BottomSheetDragHandleView
-        android:id="@+id/drag_handle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:boxCornerRadiusBottomEnd="15dp"
-        app:boxCornerRadiusBottomStart="15dp"
-        app:boxCornerRadiusTopEnd="15dp"
-        app:boxCornerRadiusTopStart="15dp"
-        app:layout_constraintTop_toTopOf="parent" />
+    android:padding="15dp"
+    app:layout_behavior="com.google.android.material.sidesheet.SideSheetBehavior">
 
     <ScrollView
         android:id="@+id/scroll_form"
@@ -22,15 +13,15 @@
         android:layout_height="wrap_content"
         android:isScrollContainer="true"
         android:nestedScrollingEnabled="true"
-        android:paddingBottom="115dp"
+        android:paddingBottom="55dp"
         app:layout_constraintBottom_toTopOf="@id/button_layout"
-        app:layout_constraintTop_toBottomOf="@id/drag_handle"
+        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:padding="15dp">
+            android:paddingVertical="15dp">
 
             <TextView
                 android:id="@+id/txt_title"
@@ -38,7 +29,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/connection_dialog_title"
                 android:textColor="@color/base_theme_light_primary"
-                android:textSize="18sp"
+                android:textSize="16sp"
                 android:textStyle="bold"
                 app:layout_constraintBottom_toTopOf="@id/txt_description"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -215,7 +206,6 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:padding="15dp"
             app:constraint_referenced_ids="btn_cancel, btn_connect"
             app:flow_horizontalGap="15dp"
             app:flow_verticalAlign="center"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,6 +67,7 @@
 
     <!-- Connection Dialog-->
     <string name="connect">Connect</string>
+    <string name="cancel">Cancel</string>
     <string name="connection_dialog_title">Liquid Galaxy Connection</string>
     <string name="connection_dialog_message">This feature requires a connection to Liquid Galaxy to function properly</string>
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -30,6 +30,19 @@
         <item name="fontFamily">@font/noto_sans</item>
         <item name="android:statusBarColor">@color/base_theme_light_background</item>
         <item name="android:windowLightStatusBar">true</item>
+
+        <item name="bottomSheetDialogTheme">@style/ThemeOverlay.App.BottomSheetDialog</item>
+        <item name="sideSheetDialogTheme">@style/ThemeOverlay.App.SideSheetDialog</item>
+    </style>
+
+    <style name="ThemeOverlay.App.BottomSheetDialog" parent="ThemeOverlay.Material3.BottomSheetDialog">
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:windowSoftInputMode">adjustResize</item>
+    </style>
+
+    <style name="ThemeOverlay.App.SideSheetDialog" parent="ThemeOverlay.Material3.SideSheetDialog">
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:windowSoftInputMode">adjustResize</item>
     </style>
 
     <style name="Theme.Lgmotion" parent="Base.Theme.Lgmotion">


### PR DESCRIPTION
Can you please tag this issue as **`hactoberfest`**?  

-----
Task Done - 
- [x] BottomSheet Dialog (Portrait Mode on Mobile device)
- [x] SideSheet Dialog (Tablet & Landscape mode on Mobile device)
-----
ScreenShots - 

- **BottomSheet Dialog on Mobile device** - (Portrait Mode)

<img width="257" alt="image" src="https://github.com/SidharthMudgil/lg-motion/assets/94984185/403ca407-9631-4ba3-bdec-dee9ece8dbe0">
<img width="257" alt="image" src="https://github.com/SidharthMudgil/lg-motion/assets/94984185/eeea1625-45f6-48e5-9077-80aa56a944f8">

-----

- **SideSheet Dialog on Mobile device** - (Landscape Mode)

<img width="921" alt="image" src="https://github.com/SidharthMudgil/lg-motion/assets/94984185/0c4fe942-9851-4c98-a3b0-c74e31845a48">
<img width="921" alt="image" src="https://github.com/SidharthMudgil/lg-motion/assets/94984185/5ef43568-b9b6-40ec-aa7c-e1977e40863b">

-----

- **SideSheet Dialog on Tablet device** - (Landscape Mode)

<img width="950" alt="image" src="https://github.com/SidharthMudgil/lg-motion/assets/94984185/97abeb3c-e859-4380-8d28-f06e12d5e257">
<img width="950" alt="image" src="https://github.com/SidharthMudgil/lg-motion/assets/94984185/76168e64-4bb6-4662-a113-f65205e0637b">

-----

- **SideSheet Dialog on Tablet device** - (Portrait Mode)

<img width="382" alt="image" src="https://github.com/SidharthMudgil/lg-motion/assets/94984185/84b85de7-e04f-4e08-bc94-80f3351f82fe">
<img width="382" alt="image" src="https://github.com/SidharthMudgil/lg-motion/assets/94984185/d8217f02-e231-439a-97e9-8544f6f182ee">
